### PR TITLE
Update repository property

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "clean": "rm -rf dist",
     "build": "babel -q -L -D ./src/ --out-dir ./dist/ --ignore ./src/**/*.spec.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tripvisto/bookshelf-jsonapi-query/"
+  },
   "keywords": [
     "bookshelf",
     "jsonapi",
@@ -44,7 +48,7 @@
       "no-confusing-arrow": 0
     }
   },
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-core": "^6.23.1",


### PR DESCRIPTION
Why:
The repository field is not present

This change addresses the need by:
Adding the field referring to the project's github url