### PR TITLE
Aggregation appeared when no aggregate query

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,7 @@ const throwUnknownRelation = (r) => {
   throw new Error(`Unknown relation: ${r}`);
 };
 const throwUnsupportedAggregation = (a) => {
-  throw new Error(`Unsuppported aggregation: ${a}`);
+  throw new Error(`Unsupported aggregation: ${a}`);
 };
 
 const hasNot = R.curry(R.compose(R.not, R.has));
@@ -346,10 +346,18 @@ const buildAggregateModel = R.curry((model, aggregations) => R.pipe(
   m => m.query(applyAggregate(m.tableName, aggregations)),
 )());
 
-const buildAggregate = R.curry((q, { model, options }) => R.pipe(
-  R.propOr([], 'aggregate'),
+const processAggregate = R.curry((model, options, aggregations) => R.pipe(
   buildAggregateModel(model),
   o => ({ model, options, aggregateModel: o }),
+)(aggregations));
+
+const buildAggregate = R.curry((q, { model, options }) => R.pipe(
+  R.propOr([], 'aggregate'),
+  R.ifElse(
+    R.isEmpty,
+    R.always({ model, options }),
+    processAggregate(model, options),
+  ),
 )(q));
 
 export default function query(Bookshelf) {

--- a/src/plugin.spec.js
+++ b/src/plugin.spec.js
@@ -204,6 +204,18 @@ describe('plugin', () => {
       });
     });
 
+    describe('posts?', () => {
+      it('returns model without aggregation', (done) => {
+        Post
+          .fetchJsonapi()
+          .then((r) => {
+            expect(r).to.not.have.property('aggregation');
+          })
+          .then(call(done))
+          .catch(done);
+      });
+    });
+
     describe('posts?filter[title]=Post 1', () => {
       it('returns post with title Post 1', (done) => {
         const q = {
@@ -499,7 +511,7 @@ describe('plugin', () => {
     });
 
     describe('posts?aggregate[foo]', () => {
-      it('throws Unsuppported aggregation: average', (done) => {
+      it('throws Unsuppported aggregation: foo', (done) => {
         const q = {
           aggregate: {
             foo: 'id',
@@ -510,7 +522,7 @@ describe('plugin', () => {
           .fetchJsonapi(q)
           .then(() => done('should be rejected'))
           .catch((e) => {
-            expect(e).to.have.property('message').that.eql('Unsuppported aggregation: foo');
+            expect(e).to.have.property('message').that.eql('Unsupported aggregation: foo');
             done();
           });
       });


### PR DESCRIPTION
Why:
Aggregation appeared even though there was no
aggregate query.

This change addresses the need by:
Processing aggregate when only aggregate query
present