### PR TITLE
Fix/filter in relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Posts.fetchJsonapi(q);
 
 The `fetchJsonapi` takes a query object as its parameter.
 The query object are most likely constructed by web frameworks
-such as [expressjs][http://expressjs.com/] from a URL query.
+such as [expressjs](http://expressjs.com/) from a URL query.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-jsonapi-query",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "Fetch bookshelf model using jsonapi query parameter",
   "main": "plugin.js",
   "scripts": {


### PR DESCRIPTION
Filter in relation broken when the relation name is not
the same with related table name, e.g.,
```
Post = Bookshelf.Model.extend({
  references() {
    return this.hasMany('Reference');
  }
});

Reference = Bookshelf.Model.extend({
  tableName: 'ref',
  post() {
    return this.belongsTo('Post')
  },
  author() {
    return this.belongsTo('Author');
  },
})

//posts?filter[references.author.name][contains]=john&include=references
```

This change addresses the need by:

Changing the way to build joins in relation. Before it used the relation
name to match the parent, which is not accurate as the `parent` is filled
with `parent` table name, to the actual related table name.