### PR TITLE
Fix bug #9, multiple filters for a field

### DIFF
--- a/src/lib/query-parser.spec.js
+++ b/src/lib/query-parser.spec.js
@@ -26,6 +26,10 @@ const query = {
     like: {
       like: 'foo',
     },
+    range: {
+      gte: '2017/01/01',
+      lte: '2017/01/30',
+    },
     'related.in': 'foo',
     'related.inArray': 'foo,bar,baz',
     'related.lt': {
@@ -289,6 +293,28 @@ describe('lib/query-parser', () => {
           operator: 'in',
           value: ['foo'],
         };
+
+        expect(r).to.have.property('filter').that.length(2);
+        expect(r).to.have.property('filter').that.include(expected1);
+        expect(r).to.have.property('filter').that.include(expected2);
+      });
+    });
+
+    describe('filter[range][gte]=2017/01/01&filter[range][lte]=2017/01/30', () => {
+      it('returns filter[Object(range >= 2017/01/01), Object(range <= 2017/01/30)]', () => {
+        const q = takeFromQuery(['filter', 'range']);
+        const expected1 = {
+          column: 'range',
+          operator: '>=',
+          value: '2017/01/01',
+        };
+        const expected2 = {
+          column: 'range',
+          operator: '<=',
+          value: '2017/01/30',
+        };
+
+        const r = lib(q);
 
         expect(r).to.have.property('filter').that.length(2);
         expect(r).to.have.property('filter').that.include(expected1);


### PR DESCRIPTION
Fix #9: the plugin can not process multiple filters for a field.
For example
```
posts?filter[published][gte]=2017-05-01 00:00:00&filter[published][lte]=2017-05-03 08:00:00
```
the plugin will only process either the `gte` or `lte` depending on
which one of both is sorted first in the parsed query parameter
(usually ordered alphabetically).

To solve the bug we added a process to catch such case (to _denormalize_ the object) so
that the parser parses the query to two different filter:
```
[
  ['published', { gte: '2017-05-01 00:00:00' }],
  ['published', { lte: '2017-05-03 08:00:00' }],
]
```